### PR TITLE
Reduce size of random array to sort for CuPy lab

### DIFF
--- a/5.1 Cupy Lab.ipynb
+++ b/5.1 Cupy Lab.ipynb
@@ -137,7 +137,7 @@
    "id": "1e0b80a2-4bb0-40a0-82e6-366a47f26b43",
    "metadata": {},
    "source": [
-    "**7. Create a random array that is `10_000` by `50_000`.**"
+    "**7. Create a random array that is `10_000` by `5_000`.**"
    ]
   },
   {


### PR DESCRIPTION
Really enjoyed today's tutorial.

I ran into an issue working through the CuPy lab on the binder instances you allocated for us today. Specifically, the instructions in NB 5.1 at Step 7 tell us to create an array of size 10_000 x 50_000. This was too large for the Tesla P100-PCIE-16GB allocated and caused OOM errors. Notably, NB 5.2 (the corresponding solutions NB) has different markdown that instructs the user to create an array of size 10_000 x 5_000 (90% smaller).

This PR just brings the markdown in NB 5.1 in-line with NB 5.2.

Thanks again for the great workshop!