### PR TITLE
Use input array in Numba hello world

### DIFF
--- a/2.0 Numba.ipynb
+++ b/2.0 Numba.ipynb
@@ -211,7 +211,7 @@
     "@cuda.jit\n",
     "def foo(input_array, output_array):\n",
     "    i = cuda.grid(1)\n",
-    "    output_array[i] = i\n",
+    "    output_array[i] = input_array[i]\n",
     "    \n",
     "foo[1, len(data)](data, output)\n",
     "\n",


### PR DESCRIPTION
I'm going through the PyData Global 2021 recording and you mentioned `input_array` should be used in this example. This PR just circles back to that to make sure that change is included in the repo. 